### PR TITLE
feat: Implement Livewire component for product variant input

### DIFF
--- a/app/Livewire/VariantInput.php
+++ b/app/Livewire/VariantInput.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+
+class VariantInput extends Component
+{
+    public $variants = ['']; // Initialize with one empty input field
+    public $variantString = '';
+    public string $inputName = 'variant'; // Default name for the hidden input
+
+    // Allow passing the existing variants when editing a product
+    public function mount($existingVariants = null, $inputName = 'variant')
+    {
+        if ($existingVariants) {
+            $this->variants = explode(',', $existingVariants);
+            if (empty($this->variants)) { // Ensure there's always at least one input
+                $this->variants = [''];
+            }
+        } else {
+            $this->variants = ['']; // Default for create form
+        }
+        $this->inputName = $inputName;
+        $this->updateVariantString(); // Initial update
+    }
+
+    public function addVariantInput()
+    {
+        $this->variants[] = '';
+        $this->updateVariantString();
+    }
+
+    public function removeVariantInput($index)
+    {
+        if (count($this->variants) > 1) { // Prevent removing the last input field
+            unset($this->variants[$index]);
+            $this->variants = array_values($this->variants); // Re-index array
+            $this->updateVariantString();
+        }
+    }
+
+    // This will be called automatically when $variants changes from the frontend
+    public function updatedVariants()
+    {
+        $this->updateVariantString();
+    }
+
+    // Custom logic to handle direct updates to individual variant inputs
+    // The `$key` will be in the format 'variants.0', 'variants.1', etc.
+    public function updated($key, $value)
+    {
+        if (str_starts_with($key, 'variants.')) {
+            $this->updateVariantString();
+        }
+    }
+
+    private function updateVariantString()
+    {
+        // Filter out any null or truly empty strings before joining,
+        // but allow strings that are just spaces (user might be typing)
+        $this->variantString = implode(',', array_filter($this->variants, function($value) {
+            return $value !== null && $value !== '';
+        }));
+    }
+
+    public function render()
+    {
+        return view('livewire.variant-input');
+    }
+}

--- a/resources/views/dashboard/create.blade.php
+++ b/resources/views/dashboard/create.blade.php
@@ -8,7 +8,7 @@
             <label for="description" class="block mb-2 text-sm font-medium">{{ __('Description') }}</label>
             <textarea id="description" name="description" class="tinymce-editor">{{ old('description') }}</textarea>
         </div>
-        <flux:input name="variant" type="text" required label="{{ __('Variants') }}" class="mb-4"/>
+        <livewire:variant-input />
         <flux:input name="image[]" type="file" required label="{{ __('Images') }}" class="mb-4" multiple/>
         <flux:input name="stock" type="number" min="0" required label="{{ __('Stock') }}" class="mb-4"/>
         <flux:input name="tags" type="text" required label="{{ __('Tags') }}" class="mb-4"/>

--- a/resources/views/dashboard/edit.blade.php
+++ b/resources/views/dashboard/edit.blade.php
@@ -10,7 +10,7 @@
             <label for="description" class="block mb-2 text-sm font-medium">{{ __('Description') }}</label>
             <textarea id="description" name="description" class="tinymce-editor">{{ old('description', $product->description) }}</textarea>
         </div>
-        <flux:input name="variant" type="text" required value="{{ old('variant', $product->variant) }}" label="{{ __('Variants') }}" class="mb-4"/>
+        <livewire:variant-input :existingVariants="$product->variant" />
         <flux:input name="stock" type="number" min="0" required value="{{ old('stock', $product->stock) }}" label="{{ __('Stock') }}" class="mb-4"/>
         <flux:input name="tags" type="text" required value="{{ old('tags', $product->tags->pluck('name')->join(', ')) }}" label="{{ __('Tags') }}" class="mb-4"/>
         <div class="mb-4">

--- a/resources/views/livewire/variant-input.blade.php
+++ b/resources/views/livewire/variant-input.blade.php
@@ -1,0 +1,19 @@
+<div>
+    <label class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">{{ __('Variants') }}</label>
+    @foreach ($variants as $index => $variant)
+        <div class="flex items-center mb-2">
+            <input type="text" wire:model.live="variants.{{ $index }}" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="{{ __('Enter variant') }}">
+            @if (count($variants) > 1)
+                <button type="button" wire:click="removeVariantInput({{ $index }})" class="ml-2 text-red-500 hover:text-red-700">
+                    {{ __('Remove') }}
+                </button>
+            @endif
+        </div>
+    @endforeach
+
+    <button type="button" wire:click="addVariantInput" class="text-blue-500 hover:text-blue-700 mt-2">
+        {{ __('+ Add Variant') }}
+    </button>
+
+    <input type="hidden" name="{{ $inputName }}" value="{{ $variantString }}">
+</div>


### PR DESCRIPTION
Replaces the comma-separated text input for product variants with a dynamic, Livewire-based interface.

Key changes:
- Added `VariantInput` Livewire component (`app/Livewire/VariantInput.php` and `resources/views/livewire/variant-input.blade.php`). This component allows you to dynamically add or remove variant input fields.
- The component manages an array of variants and updates a hidden input field with a comma-separated string, ensuring compatibility with the existing backend controller logic.
- Updated the product creation form (`resources/views/dashboard/create.blade.php`) to use the new `livewire:variant-input` component.
- Updated the product edit form (`resources/views/dashboard/edit.blade.php`) to use the `livewire:variant-input` component, including passing existing product variants for initialization.
- The `DashboardController` did not require modification as its `store` and `update` methods already expected a string for the 'variant' field, which the Livewire component continues to provide.

This change improves your experience for managing product variants by providing a more intuitive and flexible input method than manually typing comma-separated values.