### PR TITLE
feat: Implement dynamic tag input field for products

### DIFF
--- a/app/Livewire/TagInput.php
+++ b/app/Livewire/TagInput.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+
+class TagInput extends Component
+{
+    public $tags = ['']; // Initialize with one empty input field
+    public $tagString = '';
+    public string $inputName = 'tags'; // Default name for the hidden input
+
+    public function mount($existingTags = null, $inputName = 'tags')
+    {
+        if ($existingTags !== null) { // Check if existingTags is actually passed
+            $this->tags = explode(',', $existingTags);
+            // If existingTags was an empty string, explode results in an array with one empty string.
+            // If we want truly no tags to result in one empty input field for usability:
+            if (count($this->tags) === 1 && $this->tags[0] === '') {
+                 $this->tags = [''];
+            } elseif (empty($this->tags)) { // If $existingTags was something else that resulted in empty after explode (e.g. only commas)
+                 $this->tags = [''];
+            }
+        } else {
+            $this->tags = ['']; // Default for create form if no existingTags
+        }
+        $this->inputName = $inputName;
+        $this->updateTagString(); // Initial update
+    }
+
+    public function addTagInput()
+    {
+        $this->tags[] = '';
+        $this->updateTagString();
+    }
+
+    public function removeTagInput($index)
+    {
+        if (count($this->tags) > 1 || (count($this->tags) === 1 && $this->tags[0] !== '')) { // Allow removing if it's the last one but not empty
+            unset($this->tags[$index]);
+            $this->tags = array_values($this->tags); // Re-index array
+            if (empty($this->tags)) { // If all removed, add one empty back
+                $this->tags = [''];
+            }
+            $this->updateTagString();
+        }
+    }
+
+    // This will be called automatically when $tags changes from the frontend
+    public function updatedTags()
+    {
+        $this->updateTagString();
+    }
+
+    // Custom logic to handle direct updates to individual tag inputs
+    // The `$key` will be in the format 'tags.0', 'tags.1', etc.
+    public function updated($key, $value)
+    {
+        if (str_starts_with($key, 'tags.')) {
+            $this->updateTagString();
+        }
+    }
+
+    private function updateTagString()
+    {
+        // Filter out any null or truly empty strings before joining
+        $this->tagString = implode(',', array_filter($this->tags, function($value) {
+            return $value !== null && $value !== '';
+        }));
+    }
+
+    public function render()
+    {
+        return view('livewire.tag-input');
+    }
+}

--- a/resources/views/dashboard/create.blade.php
+++ b/resources/views/dashboard/create.blade.php
@@ -11,7 +11,7 @@
         <livewire:variant-input />
         <flux:input name="image[]" type="file" required label="{{ __('Images') }}" class="mb-4" multiple/>
         <flux:input name="stock" type="number" min="0" required label="{{ __('Stock') }}" class="mb-4"/>
-        <flux:input name="tags" type="text" required label="{{ __('Tags') }}" class="mb-4"/>
+        <livewire:tag-input inputName="tags" />
         <div class="mb-4">
             <flux:checkbox name="featured" value="1" label="{{ __('Featured Product') }}" />
         </div>

--- a/resources/views/dashboard/edit.blade.php
+++ b/resources/views/dashboard/edit.blade.php
@@ -12,7 +12,7 @@
         </div>
         <livewire:variant-input :existingVariants="$product->variant" />
         <flux:input name="stock" type="number" min="0" required value="{{ old('stock', $product->stock) }}" label="{{ __('Stock') }}" class="mb-4"/>
-        <flux:input name="tags" type="text" required value="{{ old('tags', $product->tags->pluck('name')->join(', ')) }}" label="{{ __('Tags') }}" class="mb-4"/>
+        <livewire:tag-input inputName="tags" :existingTags="$product->tags->pluck('name')->join(', ')" />
         <div class="mb-4">
             <flux:checkbox name="featured" value="1" :checked="$product->featured" label="{{ __('Featured Product') }}" />
         </div>

--- a/resources/views/livewire/tag-input.blade.php
+++ b/resources/views/livewire/tag-input.blade.php
@@ -1,0 +1,20 @@
+<div>
+    <label class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">{{ __('Tags') }}</label>
+    @foreach ($tags as $index => $tag)
+        <div class="flex items-center mb-2">
+            <input type="text" wire:model.live="tags.{{ $index }}" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="{{ __('Enter tag') }}">
+            {{-- Logic for showing remove button: show if more than one tag input exists, or if it's the single input but it's not empty --}}
+            @if (count($tags) > 1 || ($tags[$index] !== '' && count($tags) === 1))
+                <button type="button" wire:click="removeTagInput({{ $index }})" class="ml-2 text-red-500 hover:text-red-700">
+                    {{ __('Remove') }}
+                </button>
+            @endif
+        </div>
+    @endforeach
+
+    <button type="button" wire:click="addTagInput" class="text-blue-500 hover:text-blue-700 mt-2">
+        {{ __('+ Add Tag') }}
+    </button>
+
+    <input type="hidden" name="{{ $inputName }}" value="{{ $tagString }}">
+</div>


### PR DESCRIPTION
Replaced the static text input for tags with a dynamic Livewire component, `TagInput`, mirroring the functionality of the existing `VariantInput`.

Key changes:
- Created `app/Livewire/TagInput.php` Livewire component to manage dynamic tag fields.
- Created `resources/views/livewire/tag-input.blade.php` as the view for the component.
- Integrated `<livewire:tag-input>` into the product creation (`dashboard/create.blade.php`) and editing (`dashboard/edit.blade.php`) forms.
- The `TagInput` component provides a comma-separated string of tags, which the existing `DashboardController` methods (`store` and `update`) already handle for saving to the database.

This change enhances your experience by allowing more flexible and intuitive management of product tags.